### PR TITLE
Allow users to override High Chart defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,11 +9,14 @@ A [Highcharts](http://www.highcharts.com/) component for [Ember CLI](http://www.
 ## Usage
 
 In your template:
+
 ```handlebars
 {{high-charts content=chartData chartOptions=chartOptions}}
 ```
+
 Then in a controller you can set the `chartData` and `chartOptions` values:
-```
+
+```javascript
 import Ember from 'ember';
 
 export default Ember.Controller.extend({
@@ -43,6 +46,25 @@ export default Ember.Controller.extend({
     }
   ]
 });
+```
+
+### Configuring Default Styles
+
+Ember-highcharts provides its own set of default configurations in
+`addon/utils/option-loader.js`.  At runtime you can optionally configure custom
+styles by providing a `app/highcharts-configs/application.js` file.  This
+file should provide a hook that returns the final configuration.
+
+```javascript
+ // app/highcharts-configs/application.js
+
+ export default function(defaultOptions) {
+   defaultOptions.credits.href = 'http://www.my-great-chart.com';
+   defaultOptions.credits.text = 'great charts made cheap';
+   defaultOptions.credits.enabled = true;
+
+   return defaultOptions;
+ }
 ```
 
 ## Credit

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -1,7 +1,7 @@
 import Ember from 'ember';
-import HighchartsThemeMixin from '../mixins/highcharts-theme';
+import { setDefaultHighChartOptions } from '../utils/option-loader';
 
-export default Ember.Component.extend(HighchartsThemeMixin, {
+export default Ember.Component.extend({
   classNames: ['highcharts-wrapper'],
   content: undefined,
   chartOptions: undefined,
@@ -23,7 +23,7 @@ export default Ember.Component.extend(HighchartsThemeMixin, {
 
   _renderChart: (function() {
     this.drawLater();
-    this.buildTheme();
+    setDefaultHighChartOptions(this.container);
   }).on('didInsertElement'),
 
   contentDidChange: Ember.observer('content.@each.isLoaded', function() {

--- a/addon/utils/option-loader.js
+++ b/addon/utils/option-loader.js
@@ -1,0 +1,124 @@
+var localConfig = null;
+
+export function setDefaultHighChartOptions(container) {
+  if (!localConfig) {
+    // use options defined in highcharts-config if they exist in the container
+    var localConfigBuilder = container.lookup('highcharts-config:application');
+    if (localConfigBuilder) {
+      localConfig = localConfigBuilder(defaultOptions);
+    } else {
+      localConfig = defaultOptions;
+    }
+  }
+
+  Highcharts.setOptions(localConfig);
+}
+
+var defaultOptions = {
+  colors: [
+    '#258be2',
+    '#666666',
+    '#f45b5b',
+    '#8085e9',
+    '#8d4654',
+    '#7798bf',
+    '#aaeeee',
+    '#ff0066',
+    '#eeaaee',
+    '#55bf3b',
+    '#df5353',
+    '#7798bf',
+    '#aaeeee'
+  ],
+  chart: {
+    backgroundColor: null,
+    style: {
+      fontFamily: "'Helvetica Neue', 'Helvetica', 'Arial', sans-serif"
+    }
+  },
+  title: {
+    style: {
+      color: 'black',
+      //fontSize: '18px',
+      fontWeight: 'bold'
+    }
+  },
+  subtitle: {
+    style: {
+      color: 'black'
+    }
+  },
+  tooltip: {
+    borderWidth: 0,
+    style: {
+      fontSize: '16px'
+    }
+  },
+  legend: {
+    itemStyle: {
+      fontWeight: 'bold',
+      fontSize: '14px'
+    }
+  },
+  xAxis: {
+    labels: {
+      style: {
+        color: '#6e6e70',
+        fontSize: '16px'
+      }
+    },
+    title: {
+      style: {
+        fontSize: '14px'
+      }
+    }
+  },
+  yAxis: {
+    labels: {
+      style: {
+        color: '#6e6e70',
+        fontSize: '16px'
+      }
+    },
+    title: {
+      style: {
+        fontSize: '14px'
+      }
+    }
+  },
+  plotOptions: {
+    series: {
+      shadow: true
+    },
+    candlestick: {
+      lineColor: '#404048'
+    }
+  },
+  navigator: {
+    xAxis: {
+      gridLineColor: '#D0D0D8'
+    }
+  },
+  rangeSelector: {
+    buttonTheme: {
+      fill: 'white',
+      stroke: '#C0C0C8',
+      'stroke-width': 1,
+      states: {
+        select: {
+          fill: '#D0D0D8'
+        }
+      }
+    }
+  },
+  scrollbar: {
+    trackBorderColor: '#C0C0C8'
+  },
+  background2: '#E0E0E8',
+  global: {
+    timezoneOffset: new Date().getTimezoneOffset()
+  },
+  credits: {
+    enabled: false
+  }
+};

--- a/app/initializers/highcharts.js
+++ b/app/initializers/highcharts.js
@@ -1,0 +1,8 @@
+export function initialize(container) {
+  container.optionsForType('highcharts-config', { instantiate: false });
+}
+
+export default {
+  name: 'highcharts',
+  initialize: initialize
+};

--- a/tests/dummy/app/highcharts-configs/application.js
+++ b/tests/dummy/app/highcharts-configs/application.js
@@ -1,0 +1,7 @@
+export default function(defaultOptions) {
+  defaultOptions.credits.href = 'http://www.example.com';
+  defaultOptions.credits.text = 'ember-highcharts-configured-title';
+  defaultOptions.credits.enabled = true;
+  
+  return defaultOptions;
+}

--- a/tests/unit/components/high-charts-test.js
+++ b/tests/unit/components/high-charts-test.js
@@ -2,10 +2,14 @@ import {
   moduleForComponent,
   test
 } from 'ember-qunit';
+import { initialize } from '../../../initializers/highcharts';
 
 moduleForComponent('high-charts', 'HighChartsComponent', {
   // specify the other units that are required for this test
-  // needs: ['component:foo', 'helper:bar']
+  setup: function(container) {
+    initialize(container);
+  },
+  needs: ['highcharts-config:application']
 });
 
 test('it renders', function() {
@@ -18,4 +22,16 @@ test('it renders', function() {
   // appends the component to the page
   this.append();
   equal(component._state, 'inDOM');
+});
+
+test('has default options', function() {
+  var element = this.append();
+  var credit = element.find(':contains(Highcharts.com)');
+  equal(credit.length, 0, 'Highcharts default credits not present');
+});
+
+test('has local options', function() {
+  var element = this.append();
+  var credit = element.find(':contains(ember-highcharts-configured-title)');
+  notEqual(credit.length, 0, 'ember-highcharts-configured-title credits present');
 });


### PR DESCRIPTION
This PR is a refactor of how High Chart’s options are set by the addon
to allow consumers of the addon to more easily override the default
options.

Thanks to @mixonic for his help pairing on this.

Addresses #3