### PR TITLE
Check that a chart exists before calling destroy.

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -67,9 +67,10 @@ export default Ember.Component.extend({
     }
 
     let $element = this.$();
-    let chart    = $element.highcharts.apply($element, completeChartOptions).highcharts();
-
-    set(this, 'chart', chart);
+    if ($element) {
+      let chart    = $element.highcharts.apply($element, completeChartOptions).highcharts();
+      set(this, 'chart', chart);
+    }
   },
 
   _renderChart: on('didInsertElement', function() {


### PR DESCRIPTION
Need to check for a chart before calling destroy. Otherwise we can get the following error:
Uncaught TypeError: Cannot read property 'destroy' of null