### PR TITLE
Update initializer to work with ember 2.1.x

### DIFF
--- a/addon/utils/option-loader.js
+++ b/addon/utils/option-loader.js
@@ -3,7 +3,7 @@ var localConfig = null;
 export function setDefaultHighChartOptions(container) {
   if (!localConfig) {
     // use options defined in highcharts-config if they exist in the container
-    var localConfigBuilder = container.lookup('highcharts-config:application');
+    var localConfigBuilder = container.lookupFactory('highcharts-config:application');
     if (localConfigBuilder) {
       localConfig = localConfigBuilder(defaultOptions);
     } else {

--- a/app/initializers/highcharts.js
+++ b/app/initializers/highcharts.js
@@ -1,8 +1,0 @@
-export function initialize(container) {
-  container.optionsForType('highcharts-config', { instantiate: false });
-}
-
-export default {
-  name: 'highcharts',
-  initialize: initialize
-};

--- a/tests/unit/components/high-charts-test.js
+++ b/tests/unit/components/high-charts-test.js
@@ -2,15 +2,10 @@ import {
   moduleForComponent,
   test
 } from 'ember-qunit';
-import { initialize } from '../../../initializers/highcharts';
 
 moduleForComponent('high-charts', 'HighChartsComponent', {
   // specify the other units that are required for this test
-  needs: [ 'highcharts-config:application' ],
-  beforeEach: function() {
-    let container = this.container;
-    initialize(container);
-  }
+  needs: [ 'highcharts-config:application' ]
 });
 
 test('it renders', function(assert) {


### PR DESCRIPTION
This change adds support for the new 2.1.x container api. I've tested this change in 2.1.0, 2.0.0, and 1.13.7.

I'm not sure this is the best way to handle this api change. Let me know if you have any suggestions on how to better do this and I will update the PR.

This initializer code was originally added by @Dhaulagiri.