### PR TITLE
Add support for npm3

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,9 @@ module.exports = {
   name: 'ember-highcharts',
 
   treeForVendor: function() {
-    return this.treeGenerator(path.join(__dirname, 'node_modules'));
+    // support both flat and nested node_modules structure (npm2 vs npm3+)
+    var nodeModulesDir = require.resolve('highcharts-release').split('/highcharts-release')[0];
+    return this.treeGenerator(nodeModulesDir);
   },
 
   included: function(app) {


### PR DESCRIPTION
Here's my attempt at adding support for npm 3. This fix is inspired by the other two open PRs:

1. Using require.resolve() from #45 
2. Sticking with this.treeGenerator() from #46 

Let's see if this passes the CI tests.