### PR TITLE
Updating option detection to work with a composed addon

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,10 @@
 module.exports = {
   name: 'ember-highcharts',
 
-  included: function(app) {
+  included: function(target) {
     this._super.included.apply(this, arguments);
 
+    var app = target.app || target;
     var options = app.options.emberHighCharts || { includeHighCharts: true };
 
     if (options.includeHighCharts || options.includeHighCharts3D) {


### PR DESCRIPTION
I've been working on an private addon for my team that wraps `ember-highcharts` and noticed some unexpected behavior when moving `ember-highcharts` from `devDependencies` to `dependencies` in our `package.json`. Depending on how and where the addon is included, the app options aren't always available. This attempts to cover all scenarios.