### PR TITLE
Fix deprecation with using container.lookupFactory

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { setDefaultHighChartOptions } from '../utils/option-loader';
+import getOwner from 'ember-getowner-polyfill';
 
 const {
   Component,
@@ -78,7 +79,7 @@ export default Component.extend({
 
   _renderChart: on('didInsertElement', function() {
     this.drawAfterRender();
-    setDefaultHighChartOptions(this.container);
+    setDefaultHighChartOptions(getOwner(this));
   }),
 
   _destroyChart: on('willDestroyElement', function() {

--- a/addon/utils/option-loader.js
+++ b/addon/utils/option-loader.js
@@ -1,9 +1,9 @@
 var localConfig = null;
 
-export function setDefaultHighChartOptions(container) {
+export function setDefaultHighChartOptions(owner) {
   if (!localConfig) {
-    // use options defined in highcharts-config if they exist in the container
-    var localConfigBuilder = container.lookupFactory('highcharts-config:application');
+    // use options defined in highcharts-configs/application.js if they exist
+    var localConfigBuilder = owner._lookupFactory('highcharts-config:application');
     if (localConfigBuilder) {
       localConfig = localConfigBuilder(defaultOptions);
     } else {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "ember-cli-babel": "^5.1.3"
   },
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-getowner-polyfill": "1.0.0"
   },
   "devDependencies": {
     "broccoli-asset-rev": "^2.2.0",


### PR DESCRIPTION
In Ember 2.3 the following deprecation is thrown due to how we load the highcharts-configs/application.js config file:

"DEPRECATION: Using the injected `container` is deprecated. Please use the `getOwner` helper instead to access the owner of this object."

This commit uses the new "getOwner" public api instead of the container lookup. It uses the recommended polyfill to support older versions of ember. The `lookupFactory()` method is still private for some reason but it works with the polyfill: https://github.com/rwjblue/ember-getowner-polyfill/blob/master/addon/fake-owner.js#L26. 

Deprecation details: http://emberjs.com/deprecations/v2.x/#toc_injected-container-access