### PR TITLE
Moving bower dependencies to npm.

### DIFF
--- a/blueprints/ember-highcharts/index.js
+++ b/blueprints/ember-highcharts/index.js
@@ -4,6 +4,6 @@ module.exports = {
   normalizeEntityName: function() {},
 
   afterInstall: function() {
-    return this.addBowerPackageToProject('highcharts');
+    return this.addPackageToProject('highcharts');
   }
 };

--- a/bower.json
+++ b/bower.json
@@ -10,8 +10,7 @@
     "ember-resolver": "~0.1.20",
     "jquery": "1.11.3",
     "loader.js": "ember-cli/loader.js#3.4.0",
-    "qunit": "~1.20.0",
-    "highcharts": "~4.2.1"
+    "qunit": "~1.20.0"
   },
   "resolutions": {
     "ember": "2.3.0"

--- a/index.js
+++ b/index.js
@@ -1,6 +1,10 @@
 /* jshint node: true */
 'use strict';
 
+var Funnel = require('broccoli-funnel');
+var mergeTrees = require('broccoli-merge-trees');
+var path = require('path');
+
 module.exports = {
   name: 'ember-highcharts',
 
@@ -9,32 +13,48 @@ module.exports = {
 
     var app = target.app || target;
     var options = app.options.emberHighCharts || { includeHighCharts: true };
+    var highchartsPath = 'vendor/highcharts';
 
     if (options.includeHighCharts || options.includeHighCharts3D) {
-      app.import(app.bowerDirectory + '/highcharts/highcharts.src.js');
+      app.import(highchartsPath + '/highcharts.src.js');
     }
 
     if (options.includeHighStock) {
-      app.import(app.bowerDirectory + '/highcharts/highstock.src.js');
+      app.import(highchartsPath + '/highstock.src.js');
     }
 
     if (options.includeHighMaps) {
-      app.import(app.bowerDirectory + '/highcharts/highmaps.src.js');
+      app.import(highchartsPath + '/highmaps.src.js');
     }
 
     if (options.includeHighChartsMore) {
-      app.import(app.bowerDirectory + '/highcharts/highcharts-more.src.js');
+      app.import(highchartsPath + '/highcharts/highcharts-more.src.js');
     }
 
     if (options.includeHighCharts3D) {
-      app.import(app.bowerDirectory + '/highcharts/highcharts-3d.src.js');
+      app.import(highchartsPath + '/highcharts/highcharts-3d.src.js');
     }
 
     if (options.includeModules) {
       var modules = options.includeModules;
       for (var i = 0; i < modules.length; i++) {
-        app.import(app.bowerDirectory + '/highcharts/modules/' + modules[i] + '.src.js');
+        app.import(highchartsPath + '/modules/' + modules[i] + '.src.js');
       }
     }
+  },
+
+  treeForVendor: function(vendorTree) {
+    var trees = [];
+    var highchartsPath = path.dirname(require.resolve('highcharts'));
+
+    if (vendorTree) {
+      trees.push(vendorTree);
+    }
+
+    trees.push(new Funnel(highchartsPath, {
+      destDir: 'highcharts'
+    }));
+
+    return mergeTrees(trees);
   }
 };

--- a/package.json
+++ b/package.json
@@ -18,9 +18,8 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "ember-cli-babel": "^5.1.3"
-  },
-  "dependencies": {
+    "broccoli-funnel": "^1.0.1",
+    "broccoli-merge-trees": "^1.1.1",
     "ember-cli-babel": "^5.1.5",
     "ember-getowner-polyfill": "1.0.0"
   },
@@ -41,7 +40,8 @@
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
-    "ember-try": "~0.0.8"
+    "ember-try": "~0.0.8",
+    "highcharts": "^4.2.1"
   },
   "keywords": [
     "ember-addon",


### PR DESCRIPTION
This moves `highcharts` to npm `dependencies`. This makes the install blueprint unnecessary.