### PR TITLE
Chart is not updating when chartOptions changes

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -5,6 +5,7 @@ import getOwner from 'ember-getowner-polyfill';
 const {
   Component,
   computed,
+  observer,
   get,
   set,
   merge,
@@ -33,6 +34,10 @@ export default Component.extend({
     let defaults = { series: chartContent };
 
     return merge(defaults, chartOptions);
+  }),
+  
+  buildOptionsChanged: observer('buildOptions', function() {
+    this.drawAfterRender();
   }),
 
   didReceiveAttrs() {


### PR DESCRIPTION
I'm working on a project that needs to update a chart when a filter changes. When the chartOptions (bound in the component tag {{highcharts}}) changes, the buildOptions also changes but the chart is not updated. An observer to buildOptions was added, in order to get the component redrawn