### PR TITLE
exclude navigator series when updating data

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   ],
   "browser": true,
   "boss": true,
-  "curly": true,
+  "curly": false,
   "debug": false,
   "devel": true,
   "eqeqeq": true,

--- a/.jshintrc
+++ b/.jshintrc
@@ -7,7 +7,7 @@
   ],
   "browser": true,
   "boss": true,
-  "curly": false,
+  "curly": true,
   "debug": false,
   "devel": true,
   "eqeqeq": true,

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -39,19 +39,28 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    const content = get(this, 'content');
-    const chart = get(this, 'chart');
+    const { content, chart, mode } = this.getProperties('content', 'chart', 'mode');
     if (!content || !chart) return;
 
     let noData = chart.get('noData');
     if (noData != null) noData.remove();
 
-    // remove series that aren't navigator
-    const seriesToRemove = chart.series.filter((series) => (series.name !== 'Navigator'));
-    seriesToRemove.forEach((series) => series.remove(false));
+    // remove and update current series
+    chart.series.forEach((series) => {
+      if (series.name === 'Navigator' && mode === 'StockChart') return;
 
-    // readd and add new series
-    content.forEach((series) => chart.addSeries(series, false));
+      const contentSeriesArray = content.filter((contentSeries) => (series.name === contentSeries.name));
+      if (contentSeriesArray.length === 0) return series.remove(false);
+
+      series.setData(contentSeriesArray[0].data, false, false, false);
+    });
+
+    // add new series
+    content.forEach((contentSeries) => {
+      const chartSeriesArray = chart.series.filter((series) => (series.name === contentSeries.name));
+      if (chartSeriesArray.length > 0) return;
+      chart.addSeries(contentSeries, false);
+    });
 
     // reset navigator data
     if (chart.xAxis.length > 0) chart.xAxis[0].setExtremes();

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -39,40 +39,24 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    if (!(get(this, 'content') && get(this, 'chart'))) {
-      return;
-    }
+    const content = get(this, 'content');
+    const chart = get(this, 'chart');
+    if (!content || !chart) return;
 
-    let chart = get(this, 'chart');
     let noData = chart.get('noData');
+    if (noData != null) noData.remove();
 
-    if (noData != null) {
-      noData.remove();
-    }
+    // remove series that aren't navigator
+    const seriesToRemove = chart.series.filter((series) => (series.name !== 'Navigator'));
+    seriesToRemove.forEach((series) => series.remove(false));
 
-    let numToRemove = chart.series.length - get(this, 'content').length;
+    // readd and add new series
+    content.forEach((series) => chart.addSeries(series, false));
 
-    for (let i = numToRemove; i > 0; i--) {
-
-      let lastIndex = chart.series.length - 1;
-
-      if (chart.series[lastIndex]) {
-        chart.series[lastIndex].remove(false);
-      }
-
-    }
-
-    get(this, 'content').forEach((series, idx) => {
-
-      if (chart.series[idx]) {
-        return chart.series[idx].setData(series.data, false);
-      } else {
-        return chart.addSeries(series, false);
-      }
-    });
+    // reset navigator data
+    if (chart.xAxis.length > 0) chart.xAxis[0].setExtremes();
 
     return chart.redraw();
-
   },
 
   drawAfterRender() {

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -66,7 +66,7 @@ export default Component.extend({
         return chartSeriesToRemove.push(series);
       }
 
-      series.setData(contentSeries.data, false, false, false);
+      series.setData(contentSeries.data, false);
     });
     chartSeriesToRemove.forEach((series) => series.remove(false));
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-try": "~0.1.2",
-    "highcharts": "^4.2.1",
+    "highcharts": "^4.2.4",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -6,7 +6,8 @@ import {
   lineChartOptions,
   stockChartOptions,
   cityData,
-  stockData
+  stockData,
+  updatedStockData
 } from '../constants';
 
 moduleForComponent('high-charts', 'Integration | Component | High Charts', {
@@ -82,4 +83,30 @@ test('should have navigator series for highstock', function(assert) {
   `);
 
   assert.equal(this.$('.highcharts-navigator').length, 1, '.highcharts-navigator class is present');
+});
+
+test('should update data on all svg paths on highstock chart', function(assert) {
+  assert.expect(1);
+
+  this.set('stockChartOptions', stockChartOptions);
+  this.set('stockData', stockData);
+
+  this.render(hbs`
+    {{high-charts mode="StockChart" content=stockData chartOptions=stockChartOptions}}
+  `);
+
+  const generateDArray = () => {
+    const highchartSeries = this.$('.highcharts-series');
+    return highchartSeries.map((i) => {
+      const series = highchartSeries[i];
+      return $(series).find('path').attr('d');
+    });
+  };
+
+  const dVals = generateDArray();
+
+  this.set('stockData', updatedStockData);
+  const newDVals = generateDArray();
+
+  assert.notEqual(dVals[1], newDVals[1]);
 });

--- a/tests/integration/constants.js
+++ b/tests/integration/constants.js
@@ -53,3 +53,14 @@ export const stockData = [
     ]
   }
 ];
+
+export const updatedStockData = [
+  {
+    name: 'AAPL',
+    data: [
+      [1147651200000, 90.79],
+      [1147737600000, 89.98],
+      [1147824000000, 88.26]
+    ]
+  }
+];


### PR DESCRIPTION
Without filtering out the navigator series, if the navigator is enabled, it throws an error that the navigator data length is `undefined`.