### PR TITLE
Add test for 'noData' use case and remove unused code

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -44,11 +44,6 @@ export default Component.extend({
       return;
     }
 
-    let noData = chart.get('noData');
-    if (noData != null) {
-      noData.remove();
-    }
-
     const isStockChart = mode === 'StockChart';
 
 

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -27,6 +27,20 @@ test('should include local options', function(assert) {
     'expected credits text present');
 });
 
+test('should render empty series for no chart content', function(assert) {
+  assert.expect(2);
+
+  this.content = [];
+
+  this.render(hbs`
+    {{high-charts content=content chartOptions=lineChartOptions}}
+  `);
+
+  const $legend = this.$('.highcharts-legend .highcharts-legend-item text');
+  assert.equal($legend.length, 1, 'expected one series');
+  assert.equal($legend.first().text(), 'Series 1', 'expected default series name');
+});
+
 test('should add a series', function(assert) {
   assert.expect(2);
 


### PR DESCRIPTION
This PR contains an integration test for when `content` is an empty array. It tests the default `content` set by `buildOptions()`: https://github.com/ahmadsoe/ember-highcharts/blob/master/addon/components/high-charts.js#L28-L32

This PR also removes the following "noData" check in `didReceiveAttrs()`:

```js
let noData = chart.get('noData');
if (noData != null) {
  noData.remove();
}
```

I don't think `chart.get('noData')` will ever return a truthy value. To check the existence of the "noData" series id we would need to iterate over the chart.series array. Also, the remove() method is for removing a chart series. The charts work fine when there is no content. For example, try out the "No Series" button in the dummy app to see this experience.

So based on these reasons I think we should remove this "noData" check in `didReceiveAttrs()`. 