### PR TITLE
Series options should be updated as well as data

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -1,4 +1,6 @@
 import Ember from 'ember';
+import _lang from 'lodash/lang';
+import _collection from 'lodash/collection';
 import { setDefaultHighChartOptions } from '../utils/option-loader';
 import getOwner from 'ember-getowner-polyfill';
 
@@ -14,6 +16,21 @@ const {
 
 const assign = Ember.assign || Ember.merge;
 
+const _seriesWithoutData = function(series) {
+  // we ignore 'data' key, as if nothing else changed
+  // we'll update only data series. Also, we should
+  // ignore keys starting with _ (underscore) to avoid
+  // comparing system properties
+  return _collection.reduce(series, (result, value, key) => {
+    if (key === 'data' || key.match(/^_/)) {
+      return result;
+    } else {
+      result[key] = value;
+    }
+    return result;
+  }, {});
+};
+
 export default Component.extend({
   classNames: ['highcharts-wrapper'],
   content: undefined,
@@ -22,6 +39,8 @@ export default Component.extend({
   chart: null,
   theme: undefined,
   callback: undefined,
+
+  _previousSeries: null,
 
   buildOptions: computed('chartOptions', 'content.[]', function() {
     let chartOptions = $.extend(true, {}, get(this, 'theme'), get(this, 'chartOptions'));
@@ -39,13 +58,12 @@ export default Component.extend({
   didReceiveAttrs() {
     this._super(...arguments);
 
-    const { content, chart, mode } = this.getProperties('content', 'chart', 'mode');
+    const { content, _previousSeries, chart, mode } = this.getProperties('content', '_previousSeries', 'chart', 'mode');
     if (!content || !chart) {
       return;
     }
 
     const isStockChart = mode === 'StockChart';
-
 
     // create maps to make series data easier to work with
     const contentSeriesMap = content.reduce((contentSeriesMap, contentSeries) => {
@@ -58,6 +76,10 @@ export default Component.extend({
       return chartSeriesMap;
     }, {});
 
+    const previousSeriesMap = (_previousSeries || []).reduce((previousSeriesMap, chartSeries) => {
+      previousSeriesMap[chartSeries.name] = chartSeries;
+      return previousSeriesMap;
+    }, {});
 
     // remove and update current series
     const chartSeriesToRemove = [];
@@ -68,12 +90,17 @@ export default Component.extend({
       }
 
       const contentSeries = contentSeriesMap[series.name];
+      const previousSeries = previousSeriesMap[series.name];
 
       if (!contentSeries) {
         return chartSeriesToRemove.push(series);
       }
 
-      series.setData(contentSeries.data, false);
+      if (_lang.isEqual(_seriesWithoutData(previousSeries), _seriesWithoutData(contentSeries))) {
+        series.setData(contentSeries.data, false);
+      } else {
+        series.update(contentSeries, false);
+      }
     });
 
     chartSeriesToRemove.forEach((series) => series.remove(false));
@@ -101,7 +128,8 @@ export default Component.extend({
   },
 
   draw() {
-    let completeChartOptions = [ get(this, 'buildOptions'), get(this, 'callback') ];
+    let buildOptions = get(this, 'buildOptions');
+    let completeChartOptions = [ buildOptions, get(this, 'callback') ];
     let mode = get(this, 'mode');
 
     if (typeof mode === 'string' && !!mode) {
@@ -112,6 +140,10 @@ export default Component.extend({
     if ($element) {
       let chart = $element.highcharts.apply($element, completeChartOptions).highcharts();
       set(this, 'chart', chart);
+
+      if (buildOptions.series) {
+        set(this, '_previousSeries', buildOptions.series);
+      }
     }
   },
 

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -119,6 +119,7 @@ export default Component.extend({
       chart.xAxis[0].setExtremes();
     }
 
+    set(this, '_previousSeries', content);
 
     return chart.redraw();
   },

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
+    "ember-lodash": "0.0.10",
     "ember-resolver": "^2.0.3",
     "ember-try": "^0.2.2",
     "highcharts": "^4.2.4",

--- a/tests/dummy/app/components/chart-line-interactive.js
+++ b/tests/dummy/app/components/chart-line-interactive.js
@@ -34,6 +34,11 @@ export default Ember.Component.extend({
       this.set('chartData', newChartData);
     },
 
+    updateSeriesDataWithSeries() {
+      const newChartData = this.get('dynamicChart').updateSeriesDataWithSeries(commitStats, 2, 52);
+      this.set('chartData', newChartData);
+    },
+
     setSeriesCount(numSeries) {
       const newChartData = this.get('dynamicChart').updateSeriesCount(commitStats, numSeries);
       this.set('chartData', newChartData);

--- a/tests/dummy/app/data/commit-stats.js
+++ b/tests/dummy/app/data/commit-stats.js
@@ -1,7 +1,6 @@
 export default [
   {
     "name": "angular/angular",
-    "total": 3225,
     "data": [
       ["03/14/2015", 64],
       ["03/21/2015", 57],
@@ -59,7 +58,6 @@ export default [
   },
   {
     "name": "emberjs/ember.js",
-    "total": 1660,
     "data": [
       ["03/14/2015", 65],
       ["03/21/2015", 41],

--- a/tests/dummy/app/services/dynamic-chart.js
+++ b/tests/dummy/app/services/dynamic-chart.js
@@ -17,6 +17,18 @@ export default Ember.Service.extend({
     });
   },
 
+  updateSeriesDataWithSeries(chartData, rangeStart, rangeEnd) {
+    console.log('updateSeriesDataWithSeries');
+    const numPoints = this.getRandomInt(rangeStart, rangeEnd);
+    return chartData.map(series => {
+      return {
+        name: series.name,
+        currentTime: new Date(),
+        data: series.data.slice(0, numPoints)
+      };
+    });
+  },
+
   updateSeriesCount(chartData, numSeries) {
     console.log('setSeriesCount:', numSeries);
     const chartDataCopy = Ember.copy(chartData, true);

--- a/tests/dummy/app/templates/components/chart-line-interactive.hbs
+++ b/tests/dummy/app/templates/components/chart-line-interactive.hbs
@@ -1,4 +1,5 @@
 <button class="btn btn-default" type="button" {{action "updateSeriesData"}}>Update Series Data</button>
+<button class="btn btn-default" type="button" {{action "updateSeriesDataWithSeries"}}>Update Series Data With Series Change</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 0}}>Zero Series</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 1}}>One Series</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 2}}>Two Series</button>


### PR DESCRIPTION
Currently, there was a limitation in ember-highcharts, that prevents passing series options to the Highchart element. 
This limitation, prevents from passing important options like `pointStart` and `pointInterval` as example.

Here is our content:

```javascript
content: computed('data', function() {
    return [{
      name:  'Name of the first chart',
      color: HighchartsTheme.colors[0],
      data: current,
      pointStart: point,
      pointInterval: pointInterval,
      type: 'area'
    }, {
      name: 'Name of the second chart',
      color: HighchartsTheme.colors[1],
      data: previous,
      pointStart: point,
      pointInterval: pointInterval,
      type: 'line',
      zoneAxis: 'x',
      zones: zones
    }];
  })
```

So, if any of the options, apart from `data` changes, this changes where not reflected in the chart, because chart.redraw do not take options into account, unless you specify so.

----

In this PR we are checking if there are more options, than 1, assuming, that data is always present, and if there is more, then we call `series.update`, instead of `series.setData`. It might have some drawbacks, as Highcharts API treats .update quite "destructively":

> Update the series with a new set of options. For a clean and precise handling of new options, all methods and elements from the series is removed, and it is initiated from scratch. Therefore, this method is more performance expensive than some other utility methods like setData or setVisible.
