### PR TITLE
Improve logic for series updates

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -1,5 +1,6 @@
 import Ember from 'ember';
 import { setDefaultHighChartOptions } from '../utils/option-loader';
+import { getSeriesMap, getSeriesChanges } from '../utils/chart-data';
 import getOwner from 'ember-getowner-polyfill';
 
 const {
@@ -48,15 +49,8 @@ export default Component.extend({
 
 
     // create maps to make series data easier to work with
-    const contentSeriesMap = content.reduce((contentSeriesMap, contentSeries) => {
-      contentSeriesMap[contentSeries.name] = contentSeries;
-      return contentSeriesMap;
-    }, {});
-
-    const chartSeriesMap = chart.series.reduce((chartSeriesMap, chartSeries) => {
-      chartSeriesMap[chartSeries.name] = chartSeries;
-      return chartSeriesMap;
-    }, {});
+    const contentSeriesMap = getSeriesMap(content);
+    const chartSeriesMap = getSeriesMap(chart.series);
 
 
     // remove and update current series
@@ -73,7 +67,16 @@ export default Component.extend({
         return chartSeriesToRemove.push(series);
       }
 
-      series.setData(contentSeries.data, false);
+      const updatedKeys = getSeriesChanges(contentSeries, series);
+
+      // call series.update() when other series attributes like pointStart have changed
+      if (updatedKeys.length) {
+        series.update(contentSeries, false);
+      }
+      else {
+        series.setData(contentSeries.data, false);
+      }
+
     });
 
     chartSeriesToRemove.forEach((series) => series.remove(false));

--- a/addon/utils/chart-data.js
+++ b/addon/utils/chart-data.js
@@ -1,0 +1,21 @@
+export function getSeriesMap(seriesGroup) {
+  const seriesMap = seriesGroup.reduce((seriesMap, seriesItem) => {
+    seriesMap[seriesItem.name] = seriesItem;
+    return seriesMap;
+  }, {});
+
+  return seriesMap;
+}
+
+export function getSeriesChanges(contentSeries, series) {
+  const updatedKeys = Object.keys(contentSeries).filter(key => {
+    const isValidKey = key !== 'data' && key.charAt(0) !== '_';
+    const isValidType = ['object', 'function'].indexOf(typeof contentSeries[key]) === -1;
+    const isTheSame = contentSeries[key] === series[key];
+
+    return isValidKey && isValidType && !isTheSame;
+  });
+
+  // returns a list of updated keys
+  return updatedKeys;
+}

--- a/tests/dummy/app/components/chart-line-interactive.js
+++ b/tests/dummy/app/components/chart-line-interactive.js
@@ -34,6 +34,17 @@ export default Ember.Component.extend({
       this.set('chartData', newChartData);
     },
 
+    fullUpdateToSeries() {
+      let newChartData = this.get('dynamicChart').updateSeriesData(commitStats, 2, 52);
+
+      // updated currentTime attribute causes series.update() to be used instead of series.setData()
+      newChartData.forEach(series => {
+        series.currentTime = Date.now();
+      });
+
+      this.set('chartData', newChartData);
+    },
+
     setSeriesCount(numSeries) {
       const newChartData = this.get('dynamicChart').updateSeriesCount(commitStats, numSeries);
       this.set('chartData', newChartData);

--- a/tests/dummy/app/data/commit-stats.js
+++ b/tests/dummy/app/data/commit-stats.js
@@ -1,7 +1,6 @@
 export default [
   {
     "name": "angular/angular",
-    "total": 3225,
     "data": [
       ["03/14/2015", 64],
       ["03/21/2015", 57],
@@ -59,7 +58,6 @@ export default [
   },
   {
     "name": "emberjs/ember.js",
-    "total": 1660,
     "data": [
       ["03/14/2015", 65],
       ["03/21/2015", 41],

--- a/tests/dummy/app/templates/components/chart-line-interactive.hbs
+++ b/tests/dummy/app/templates/components/chart-line-interactive.hbs
@@ -1,4 +1,5 @@
 <button class="btn btn-default" type="button" {{action "updateSeriesData"}}>Update Series Data</button>
+<button class="btn btn-default" type="button" {{action "fullUpdateToSeries"}}>Full Update to Series</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 0}}>Zero Series</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 1}}>One Series</button>
 <button class="btn btn-default" type="button" {{action "setSeriesCount" 2}}>Two Series</button>

--- a/tests/unit/utils/chart-data-test.js
+++ b/tests/unit/utils/chart-data-test.js
@@ -1,0 +1,69 @@
+import { getSeriesMap, getSeriesChanges } from 'ember-highcharts/utils/chart-data';
+import { module, test } from 'qunit';
+
+module('Unit | Utility | Chart data');
+
+test('#getSeriesMap returns valid object', function(assert) {
+  const seriesGroup = [
+    { name: 'series1', data: [1, 2] },
+    { name: 'series2', data: [3, 4] }
+  ];
+
+  const expectedSeriesMap = {
+    series1: {
+      name: 'series1',
+      data: [1, 2]
+    },
+    series2: {
+      name: 'series2',
+      data: [3, 4]
+    }
+  };
+
+  assert.deepEqual(getSeriesMap(seriesGroup), expectedSeriesMap);
+});
+
+test('#getSeriesChanges detects "name" key change', function(assert) {
+  const contentSeries = {
+    name: 'new series name',
+    data: [1, 2]
+  };
+
+  const series = {
+    name: 'series1',
+    data: [1, 2]
+  };
+
+  const keys = getSeriesChanges(contentSeries, series);
+
+  assert.equal(keys.length, 1);
+  assert.equal(keys[0], 'name');
+});
+
+test('#getSeriesChanges ignores changes for invalid keys', function(assert) {
+  const contentSeries = {
+    name: 'new series name',
+    data: [3, 4],
+    _legendItemPos: 2,
+    obj: { foo: 'buzz' },
+    fun: () => console.log('more fun')
+  };
+
+  const series = {
+    name: 'series1',
+    data: [1, 2],
+    _legendItemPos: 1,
+    obj: { foo: 'bar' },
+    fun: () => console.log('fun')
+  };
+
+  const keys = getSeriesChanges(contentSeries, series);
+
+  assert.equal(keys.indexOf('data'), -1, 'expected "data" key to be ignored');
+  assert.equal(keys.indexOf('_legendItemPos'), -1, 'expected private keys to be ignored');
+  assert.equal(keys.indexOf('obj'), -1, 'expected object types to be ignored');
+  assert.equal(keys.indexOf('fun'), -1, 'expected function types to be ignored');
+
+  assert.equal(keys.length, 1);
+  assert.equal(keys[0], 'name');
+});


### PR DESCRIPTION
Related: #91  

This PR attempts to solve the problem of updating data when `pointInterval` is used. Ex: http://jsfiddle.net/gh/get/jquery/1.9.1/highslide-software/highcharts.com/tree/master/samples/highcharts/plotoptions/series-pointstart-datetime/

Currently, the series data never refreshes when `pointInterval` or `pointStart` change. This PR fixes this problem by taking advantage of `series.update` when appropriate: http://api.highcharts.com/highcharts#Series.update

Highcharts has a big API so it requires a lot of code to support the many use cases. There are certain use cases that are not covered by this solution. So it may not be the best approach but it is minimal and seems to support the common "redraw" use cases. This is still a WIP and needs the following before its ready to be merged:

- [x] Add tests for series.setData - covered by unit tests
- [x] Add tests for series.update - coverered by unit tests

