### PR TITLE
Support HighCharts 'styled' mode - separating styling concerns using CSS - applicable since version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ You can add the `emberHighCharts` option to your `ember-cli-build.js` file to lo
 var app = new EmberApp({
   emberHighCharts: {
     includeHighCharts: false,
+    includeHighChartsStyledMode: false,
     includeHighStock: true,
     includeHighMaps: false,
     includeHighChartsMore: true,
@@ -167,6 +168,19 @@ var app = new EmberApp({
 });
 ```
 
+###Support for Styled Mode
+
+As of version 5, HighCharts supports CSS styling - if you wish to use this use the following configuration:
+
+```js
+var app = new EmberApp({
+  emberHighCharts: {
+    includeHighChartsStyledMode: true
+  }
+});
+```
+
+You will need to add CSS to get anything display properly; more details can be found in the HighCharts article: [Chart Design and Style > Style by CSS](Style by CSS). The [linked CodePen example](http://codepen.io/TorsteinHonsi/pen/KMNbRN) includes a comprehensive SCSS file. 
 
 ### Global Highcharts Config Options
 

--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ var app = new EmberApp({
 });
 ```
 
-You will need to add a number of CSS rules for a chart to display properly; more details can be found in the HighCharts article: [Chart Design and Style > Style by CSS](Style by CSS). The [linked CodePen example](http://codepen.io/TorsteinHonsi/pen/KMNbRN) includes a comprehensive SCSS file. 
+You will need to add a number of CSS rules for a chart to display properly; more details can be found in the HighCharts article: [Chart Design and Style > Style by CSS](http://www.highcharts.com/docs/chart-design-and-style/style-by-css). The [linked CodePen example](http://codepen.io/TorsteinHonsi/pen/KMNbRN) includes a comprehensive SCSS file. 
 
 ### Global Highcharts Config Options
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ var app = new EmberApp({
 
 ###Support for Styled Mode
 
-As of version 5, HighCharts supports CSS styling - if you wish to use this use the following configuration:
+As of version 5, HighCharts supports CSS styling - if you wish to use this, use the following configuration:
 
 ```js
 var app = new EmberApp({
@@ -180,7 +180,7 @@ var app = new EmberApp({
 });
 ```
 
-You will need to add CSS to get anything display properly; more details can be found in the HighCharts article: [Chart Design and Style > Style by CSS](Style by CSS). The [linked CodePen example](http://codepen.io/TorsteinHonsi/pen/KMNbRN) includes a comprehensive SCSS file. 
+You will need to add a number of CSS rules for a chart to display properly; more details can be found in the HighCharts article: [Chart Design and Style > Style by CSS](Style by CSS). The [linked CodePen example](http://codepen.io/TorsteinHonsi/pen/KMNbRN) includes a comprehensive SCSS file. 
 
 ### Global Highcharts Config Options
 

--- a/index.js
+++ b/index.js
@@ -18,6 +18,9 @@ module.exports = {
     if (options.includeHighCharts) {
       app.import(path.join(highchartsPath, 'highcharts.src.js'));
     }
+    else if (options.includeHighChartsStyledMode) {
+      app.import(path.join(highchartsPath, '/js/highcharts.src.js'));
+    }
 
     if (options.includeHighStock) {
       app.import(path.join(highchartsPath, 'highstock.src.js'));

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "highcharts": "~5.0.0",
+    "highcharts": "^4.2.4",
     "loader.js": "^4.0.1"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "ember-export-application-global": "^1.0.5",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
-    "highcharts": "^4.2.4",
+    "highcharts": "~5.0.0",
     "loader.js": "^4.0.1"
   },
   "keywords": [


### PR DESCRIPTION
Added some very basic support to allow use of the [Styled mode](http://www.highcharts.com/docs/chart-design-and-style/style-by-css) core HighCharts library.