### PR TITLE
Switching nested addon detection to findHost

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,10 +8,24 @@ var path = require('path');
 module.exports = {
   name: 'ember-highcharts',
 
-  included: function(target) {
+  included: function() {
     this._super.included.apply(this, arguments);
 
-    var app = target.app || target;
+    var app;
+
+    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+    // use that.
+    if (typeof this._findHost === 'function') {
+      app = this._findHost();
+    } else {
+      // Otherwise, we'll use this implementation borrowed from the _findHost()
+      // method in ember-cli.
+      var current = this;
+      do {
+        app = current.app || app;
+      } while (current.parent.parent && (current = current.parent));
+    }
+
     var options = app.options.emberHighCharts || { includeHighCharts: true };
     var highchartsPath = 'vendor/highcharts';
 


### PR DESCRIPTION
When including `ember-highcharts` as a deeply nested addon, the default highcharts configuration is used. This causes issues when the top-level addon defines a configuration that includes HighStocks or HighMaps because then Highcharts is included twice. This PR uses ember-cli's `findHost` method to traverse up the addon tree and find the top-level addon so it only uses that configuration.