### PR TITLE
Move boostrap to NPM and out of bower

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,4 +1,0 @@
-{
-  "directory": "bower_components",
-  "analytics": false
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,11 +40,9 @@ matrix:
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH=$HOME/.yarn/bin:$PATH
-  - yarn global add bower
 
 install:
   - yarn install --no-lockfile --non-interactive
-  - bower install
 
 script:
   - yarn lint:js

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,0 @@
-{
-  "name": "ember-highcharts",
-  "dependencies": {
-    "bootstrap": "^3.3.6"
-  }
-}

--- a/ember-cli-build.js
+++ b/ember-cli-build.js
@@ -28,7 +28,7 @@ module.exports = function(defaults) {
     behave. You most likely want to be modifying `./index.js` or app's build file
   */
 
-  app.import('bower_components/bootstrap/dist/css/bootstrap.css');
+  app.import('node_modules/bootstrap/dist/css/bootstrap.css');
 
   return app.toTree();
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
+    "bootstrap": "3.3.7",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^1.2.0",
     "ember-assign-polyfill": "^2.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,6 +1041,10 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
+bootstrap@3.3.7:
+  version "3.3.7"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+
 bower-config@^1.3.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/bower-config/-/bower-config-1.4.0.tgz#16c38c1135f8071c19f25938d61b0d8cbf18d3f1"
@@ -3592,7 +3596,7 @@ heimdalljs@^0.2.0, heimdalljs@^0.2.1, heimdalljs@^0.2.3:
     rsvp "~3.2.1"
 
 highcharts@^5.0.12:
-  version v5.0.12
+  version "5.0.12"
   resolved "https://registry.yarnpkg.com/highcharts/-/highcharts-5.0.12.tgz#f73b970fe5c7f04100220b64aa7bd7fb019d11e2"
 
 hoek@2.x.x:


### PR DESCRIPTION
In the spirit of  ember-cli moving away from bower, this PR moves bootstrap from bower to node-modules.

* Tests pass
* dummy app loads and works correctly