### PR TITLE
Remove jQuery from high-charts component

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -5,10 +5,18 @@ import Component from '@ember/component';
 import { getOwner } from '@ember/application';
 import { set, getProperties, get, computed } from '@ember/object';
 import { run } from '@ember/runloop';
-import $ from 'jquery';
 import { setDefaultHighChartOptions } from '../utils/option-loader';
 import { getSeriesMap, getSeriesChanges } from '../utils/chart-data';
 import layout from 'ember-highcharts/templates/components/high-charts';
+
+/* Map ember-highcharts modes to Highcharts methods
+ * https://api.highcharts.com/class-reference/Highcharts.html
+ */
+const CHART_TYPES = {
+  StockChart: 'stockChart',
+  Map: 'mapChart',
+  undefined: 'chart'
+};
 
 export default Component.extend({
   layout,
@@ -21,7 +29,7 @@ export default Component.extend({
   callback: undefined,
 
   buildOptions: computed('chartOptions', 'content.[]', function() {
-    let chartOptions = $.extend(true, {}, get(this, 'theme'), get(this, 'chartOptions'));
+    let chartOptions = assign({}, get(this, 'theme'), get(this, 'chartOptions'));
     let chartContent = get(this, 'content');
 
     // if 'no-data-to-display' module has been imported, keep empty series and leave it to highcharts to show no data label.
@@ -99,16 +107,12 @@ export default Component.extend({
   },
 
   draw() {
-    let $element = this.$('.chart-container');
-    let mode = get(this, 'mode');
+    let element = this.element && this.element.querySelector('.chart-container');
+    let mode = CHART_TYPES[get(this, 'mode')];
     let completeChartOptions = [get(this, 'buildOptions'), get(this, 'callback')];
 
-    if (typeof mode === 'string' && !!mode) {
-      completeChartOptions.unshift(mode);
-    }
-
-    if ($element) {
-      let chart = $element.highcharts(...completeChartOptions).highcharts();
+    if (element) {
+      let chart = Highcharts[mode](element, ...completeChartOptions);
       set(this, 'chart', chart);
     }
   },

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -1,4 +1,3 @@
-import $ from 'jquery';
 import { copy } from '@ember/object/internals';
 import { moduleForComponent, test } from 'ember-qunit';
 import hbs from 'htmlbars-inline-precompile';
@@ -23,9 +22,9 @@ test('should include local options', function(assert) {
   `);
 
   // custom highcharts-configs/application.js is auto-loaded from tests/dummy/app
-  assert.equal(this.$('text:contains(Highcharts.com)').length, 0, 'default credits not present');
-  assert.notEqual(this.$(':contains(ember-highcharts-configured-title)').length, 0,
-    'expected credits text present');
+  let highchartsCreditsText = document.querySelector('.highcharts-credits').textContent.trim();
+  assert.notOk(highchartsCreditsText.match('Highcharts.com'), 'default credits not present');
+  assert.equal(highchartsCreditsText, 'ember-highcharts-configured-title', 'expected credits text present');
 });
 
 test('should render empty series for no chart content', function(assert) {
@@ -37,9 +36,9 @@ test('should render empty series for no chart content', function(assert) {
     {{high-charts content=content chartOptions=lineChartOptions}}
   `);
 
-  let $legend = this.$('.highcharts-legend .highcharts-legend-item text');
-  assert.equal($legend.length, 1, 'expected one series');
-  assert.equal($legend.first().text(), 'Series 1', 'expected default series name');
+  let legend = document.querySelectorAll('.highcharts-legend .highcharts-legend-item text');
+  assert.equal(legend.length, 1, 'expected one series');
+  assert.equal(legend[0].textContent.trim(), 'Series 1', 'expected default series name');
 });
 
 test('should add a series', function(assert) {
@@ -51,7 +50,7 @@ test('should add a series', function(assert) {
     {{high-charts content=cityData chartOptions=lineChartOptions}}
   `);
 
-  assert.equal(this.$('.highcharts-legend .highcharts-legend-item').length, 3, 'base series count');
+  assert.equal(document.querySelectorAll('.highcharts-legend .highcharts-legend-item').length, 3, 'base series count');
 
   // add a series to chart content
   let cityDataCopy = copy(cityData, true);
@@ -65,7 +64,7 @@ test('should add a series', function(assert) {
   });
 
   this.set('cityData', cityDataCopy);
-  assert.equal(this.$('.highcharts-legend .highcharts-legend-item').length, 4, 'new series count');
+  assert.equal(document.querySelectorAll('.highcharts-legend .highcharts-legend-item').length, 4, 'new series count');
 });
 
 test('should remove a series', function(assert) {
@@ -77,14 +76,14 @@ test('should remove a series', function(assert) {
     {{high-charts content=cityData chartOptions=lineChartOptions}}
   `);
 
-  assert.equal(this.$('.highcharts-legend .highcharts-legend-item').length, 3, 'base series count');
+  assert.equal(document.querySelectorAll('.highcharts-legend .highcharts-legend-item').length, 3, 'base series count');
 
   // remove a series from chart content
   let cityDataCopy = copy(cityData, true);
   cityDataCopy = cityDataCopy.slice(0, 2);
 
   this.set('cityData', cityDataCopy);
-  assert.equal(this.$('.highcharts-legend .highcharts-legend-item').length, 2, 'new series count');
+  assert.equal(document.querySelectorAll('.highcharts-legend .highcharts-legend-item').length, 2, 'new series count');
 });
 
 test('should have navigator series for highstock', function(assert) {
@@ -97,7 +96,7 @@ test('should have navigator series for highstock', function(assert) {
     {{high-charts mode="StockChart" content=stockData chartOptions=stockChartOptions}}
   `);
 
-  assert.equal(this.$('.highcharts-navigator').length, 1, '.highcharts-navigator class is present');
+  assert.equal(document.querySelectorAll('.highcharts-navigator').length, 1, '.highcharts-navigator class is present');
 });
 
 test('should update data on all svg paths on highstock chart', function(assert) {
@@ -111,10 +110,9 @@ test('should update data on all svg paths on highstock chart', function(assert) 
   `);
 
   let generateDArray = () => {
-    let highchartSeries = this.$('.highcharts-series');
-    return highchartSeries.map((i) => {
-      let series = highchartSeries[i];
-      return $(series).find('path').attr('d');
+    let highchartSeries = Array.from(document.querySelectorAll('.highcharts-series'));
+    return highchartSeries.map((series) => {
+      return series.querySelector('path').getAttribute('d');
     });
   };
 
@@ -135,5 +133,5 @@ test('should yield the chart instance when used in block form', function(assert)
     {{/high-charts}}
   `);
 
-  assert.equal(this.$('.chart-test-content').text(), 3, 'chart instance series count');
+  assert.equal(document.querySelector('.chart-test-content').textContent, 3, 'chart instance series count');
 });


### PR DESCRIPTION
[Ember is moving away from jQuery](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md), and removing it from this addon will help future Ember apps be jQuery-free.

This PR uses the [vanilla way](https://github.com/emberjs/rfcs/blob/master/text/0294-optional-jquery.md) of creating a Highchart.

If the maintainers are amenable to a major version bump, the `mode`s laid out in the README could be changed to match the Highchart methods, which would allow me to remove the [`CHART_TYPES`](https://github.com/ahmadsoe/ember-highcharts/compare/master...nlfurniss:remove-jquery?expand=1#diff-ef689950324b088ba7bdccaa9783ec65R15) obj and simple do:
```js
draw() {
  ...
  let mode = getWithDefault(this, mode, 'chart');
  ...
  let chart = Highcharts[mode](element, ...completeChartOptions);
}
```

* Tests pass
* dummy app serves and works correctly