### PR TITLE
Add chartOptions observer to force chart refresh on chartOptions change

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -3,7 +3,7 @@ import { assign } from '@ember/polyfills';
 
 import Component from '@ember/component';
 import { getOwner } from '@ember/application';
-import { set, getProperties, get, computed } from '@ember/object';
+import { set, getProperties, get, computed, observer } from '@ember/object';
 import { run } from '@ember/runloop';
 import { setDefaultHighChartOptions } from '../utils/option-loader';
 import { getSeriesMap, getSeriesChanges } from '../utils/chart-data';
@@ -44,6 +44,10 @@ export default Component.extend({
     let defaults = { series: chartContent };
 
     return assign(defaults, chartOptions);
+  }),
+
+  chartOptionsObserver: observer('chartOptions', function() {
+    this.drawAfterRender();
   }),
 
   didReceiveAttrs() {


### PR DESCRIPTION
Hello,

I've made a simple change in `components/high-charts.js` that make a chart update on options change.

I need this in my apps since I have one chart area that may be used to render pies or whatever else without reinserting the `{{high-chart}}` component.

Hope it could help somebody else.

Cheers,

René