### PR TITLE
Component should not throw an exception on a "falsy" mode attribute

### DIFF
--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -110,8 +110,8 @@ export default Component.extend({
 
   draw() {
     let element = this.element && this.element.querySelector('.chart-container');
-    let modeAttr = get(this, 'mode');
-    let mode = CHART_TYPES[!modeAttr ? undefined : modeAttr];
+    let modeAttr = get(this, 'mode') || undefined;
+    let mode = CHART_TYPES[modeAttr];
     let completeChartOptions = [get(this, 'buildOptions'), get(this, 'callback')];
 
     if (element) {

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -110,7 +110,8 @@ export default Component.extend({
 
   draw() {
     let element = this.element && this.element.querySelector('.chart-container');
-    let mode = CHART_TYPES[get(this, 'mode')];
+    let modeAttr = get(this, 'mode');
+    let mode = CHART_TYPES[!modeAttr ? undefined : modeAttr];
     let completeChartOptions = [get(this, 'buildOptions'), get(this, 'callback')];
 
     if (element) {

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -135,3 +135,27 @@ test('should yield the chart instance when used in block form', function(assert)
 
   assert.equal(document.querySelector('.chart-test-content').textContent, 3, 'chart instance series count');
 });
+
+test('should accept "falsy" mode attribute for default highcharts operation', function(assert) {
+  assert.expect(4);
+
+  this.render(hbs`
+    {{high-charts}}
+  `);
+  assert.equal(document.querySelectorAll('.highcharts-container').length, 1, 'we rendered a chart without a mode specified');
+
+  this.render(hbs`
+    {{high-charts mode=""}}
+  `);
+  assert.equal(document.querySelectorAll('.highcharts-container').length, 1, 'we rendered a chart with empty string mode');
+
+  this.render(hbs`
+    {{high-charts mode=false}}
+  `);
+  assert.equal(document.querySelectorAll('.highcharts-container').length, 1, 'we rendered a chart with false boolean mode');
+
+  this.render(hbs`
+    {{high-charts mode=null}}
+  `);
+  assert.equal(document.querySelectorAll('.highcharts-container').length, 1, 'we rendered a chart with null mode');
+});


### PR DESCRIPTION
As by documentation, regression introduced by
edf7390e3856cf366ba2b316d777117f4aae8a5b