### PR TITLE
Bump bootstrap version to fix security vulnerability

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test": "ember try:each"
   },
   "dependencies": {
-    "bootstrap": "3.3.7",
+    "bootstrap": "3.4.1",
     "broccoli-funnel": "^2.0.1",
     "broccoli-merge-trees": "^1.2.0",
     "deepmerge": "2.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1041,9 +1041,10 @@ boom@2.x.x:
   dependencies:
     hoek "2.x.x"
 
-bootstrap@3.3.7:
-  version "3.3.7"
-  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.3.7.tgz#5a389394549f23330875a3b150656574f8a9eb71"
+bootstrap@3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/bootstrap/-/bootstrap-3.4.1.tgz#c3a347d419e289ad11f4033e3c4132b87c081d72"
+  integrity sha512-yN5oZVmRCwe5aKwzRj6736nSmKDX7pLYwsXiCj/EYmo16hODaBiT4En5btW/jhBF/seV+XMx3aYwukYC3A49DA==
 
 bower-config@^1.3.0:
   version "1.4.0"


### PR DESCRIPTION
- Bump `bootstrap` from `3.3.7` to `3.4.1` to fix XSS vulnerability (CVE-2019-8331) described https://github.com/twbs/bootstrap/releases/tag/v3.4.1.
- Addresses https://github.com/ahmadsoe/ember-highcharts/issues/163