### PR TITLE
Use the "app" argument if available

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,22 +17,22 @@ module.exports = {
     }
   },
 
-  included() {
+  included(app) {
     this._super.included.apply(this, arguments);
 
-    let app;
-
-    // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
-    // use that.
-    if (typeof this._findHost === 'function') {
-      app = this._findHost();
-    } else {
-      // Otherwise, we'll use this implementation borrowed from the _findHost()
-      // method in ember-cli.
-      let current = this;
-      do {
-        app = current.app || app;
-      } while (current.parent.parent && (current = current.parent));
+    if (typeof app.import !== 'function') {
+      // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
+      // use that.
+      if (typeof this._findHost === 'function') {
+        app = this._findHost();
+      } else {
+        // Otherwise, we'll use this implementation borrowed from the _findHost()
+        // method in ember-cli.
+        let current = this;
+        do {
+          app = current.app || app;
+        } while (current.parent.parent && (current = current.parent));
+      }
     }
 
     let options = app.options.emberHighCharts || { includeHighCharts: true };

--- a/index.js
+++ b/index.js
@@ -20,6 +20,9 @@ module.exports = {
   included(app) {
     this._super.included.apply(this, arguments);
 
+    // The app argument passed to included is the host app or parent addon.
+    // And the addon has a `import` api exposed since ember-cli/ember-cli#5877.
+    // If the `app.import` is available we can just use that.
     if (typeof app.import !== 'function') {
       // If the addon has the _findHost() method (in ember-cli >= 2.7.0), we'll just
       // use that.


### PR DESCRIPTION
The `app` argument passed to `included` is the host app or parent addon and the addon has a `import` api exposed since https://github.com/ember-cli/ember-cli/pull/5877.

This PR does no changes to normal ember app but the app with a lazy engine which depend on `ember-highcharts` directly, it could distribute the `hightcharts` vendor to the `engine-vendor.js` instead of the `vendor.js` of the whole app so that other engines do not have to download the `hightcharts` vendor(also need other tricks like adding the "ember-highcharts" to the `addons.blacklist` of the whole app option).