### PR TITLE
Handle when chartOptions change

### DIFF
--- a/addon/components/high-charts.hbs
+++ b/addon/components/high-charts.hbs
@@ -2,10 +2,9 @@
   {{did-insert this.onDidInsert}}
   {{did-update
     this.onDidUpdate
-    this.content
-    this.chartOptions
-    this.theme
-    this.mode
+    content=this.content
+    chartOptions=this.chartOptions
+    mode=this.mode
   }}
   ...attributes
 >

--- a/addon/components/high-charts.js
+++ b/addon/components/high-charts.js
@@ -76,12 +76,15 @@ export default class HighCharts extends Component {
   }
 
   @action
-  onDidUpdate() {
-    const { content, chart, mode } = this;
+  onDidUpdate(elem, positionalArgs, { content, chartOptions, mode}) {
+    const { chart } = this;
 
     if (!content || !chart) {
       return;
     }
+
+    // Set any new chartOptions, do no redraw as we'll do that later
+    chart.update(chartOptions, false);
 
     const isStockChart = mode === 'StockChart';
     // create maps to make series data easier to work with

--- a/tests/integration/components/high-charts-test.js
+++ b/tests/integration/components/high-charts-test.js
@@ -201,4 +201,26 @@ module('Integration | Component | High Charts', function(hooks) {
       />
     `);
   });
+
+  test('should update when the chartOptions change', async function(assert) {
+    assert.expect(4);
+
+    this.cityData = cityData;
+    this.lineChartOptions = lineChartOptions;
+
+    await render(hbs`
+      <HighCharts
+        @content={{this.cityData}}
+        @chartOptions={{this.lineChartOptions}}
+      />
+    `);
+
+    assert.equal(document.querySelector('.highcharts-title').textContent, 'Series Test', 'Title is correct');
+    assert.equal(document.querySelector('.highcharts-subtitle').textContent, '', 'Subtitle is empty');
+
+    this.set('lineChartOptions', { subtitle: { text: 'Updated!'}});
+
+    assert.equal(document.querySelector('.highcharts-title').textContent, 'Series Test', 'Title remains the same');
+    assert.equal(document.querySelector('.highcharts-subtitle').textContent, 'Updated!', 'new series count');
+  });
 });


### PR DESCRIPTION
If passed in `chartOptions` change, the chart now reflects that