### PR TITLE
Add link to modules dir in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,13 +134,14 @@ var app = new EmberApp({
     includeHighChartsMore: true,
     includeHighCharts3D: true,
     includeModules: ['map', 'broken-axis', 'heatmap', ... ]
-    /* available modules:
+    /* Some available modules include:
       boost, broken-axis, canvas-tools, data, drilldown, exporting, funnel,
-      heatmap, map, no-data-to-display, offline-exporting, solid-gauge, treemap
+      heatmap, map, no-data-to-display, offline-exporting, solid-gauge, treemap.
     */
   }
 });
 ```
+All modules can be found [here](https://github.com/highcharts/highcharts/tree/master/ts/masters/modules).
 
 ### Highstock
 


### PR DESCRIPTION
Several issued have been filed because the modules list was incomplete. This makes it clearer that that array is only a partial list and the rest can be found in the HighCharts repo