### PR TITLE
Remove validate-peer-dependencies

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,18 +3,9 @@
 const Funnel = require('broccoli-funnel');
 const mergeTrees = require('broccoli-merge-trees');
 const path = require('path');
-const validatePeerDependencies = require('validate-peer-dependencies');
 
 module.exports = {
   name: require('./package').name,
-
-  init() {
-    this._super.init.apply(this, arguments);
-
-    validatePeerDependencies(__dirname, {
-      resolvePeerDependenciesFrom: this.parent.root,
-    });
-  },
 
   included(app) {
     this._super.included.apply(this, arguments);

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "ember-cli-babel": "^7.26.11",
     "ember-cli-htmlbars": "^6.2.0",
     "ember-copy": "^2.0.1",
-    "validate-peer-dependencies": "^2.0.0",
     "webpack": "^5.78.0"
   },
   "devDependencies": {


### PR DESCRIPTION
We should not need to validate peer dependencies manually. It is up to users to ensure they are correctly enforcing them.