### PR TITLE
v2 test app path in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ export default class BarBasic extends Component {
 />
 ```
 
-Check out more chart examples in the [tests/dummy app](tests/dummy/app) in this repo.
+Check out more chart examples in the [test-app/app/components](test-app/app/components) in this repo.
 
 ## Configuration
 


### PR DESCRIPTION
- Broken link
- This fix
- Also think better starting place is `/components` as that's the first place people will want to explore